### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "magento/module-theme": "101.0.* || 101.1.*",
         "magento/module-translation": "100.3.* || 100.4.*",
         "magento/module-ui": "101.1.* || 101.2.*",
-        "guzzlehttp/guzzle": "^6.0",
+        "guzzlehttp/guzzle": "^6.0 || ^7.0",
         "myclabs/php-enum": "^1.6",
         "zendframework/zend-hydrator": "^1.1 || ^2.1"
     },


### PR DESCRIPTION
244 compatibility fix

## Description
guzzlehttp in 2.4.4 is 7.x, so this should be updated


## Motivation and Context
this module is blocking Magento upgrade to 2.4.4

## How Has This Been Tested?
this has backwardcompatibility

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
